### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Build
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/rohankishore/Aura-Text/security/code-scanning/1](https://github.com/rohankishore/Aura-Text/security/code-scanning/1)

To fix this issue, you should set the least-privilege permissions for the workflow by adding a `permissions` block. Since this workflow checks out code, builds, and uploads artifacts but does not interact with pull requests, issues, or the repository contents in a write capacity, the least privilege needed is typically `contents: read`. This satisfies the requirement to protect the GITHUB_TOKEN and adhere to the principle of least privilege. The fix involves inserting a `permissions:` block at the top level of the workflow (after the `name:` key and before `on:`), or within the specific job if more granular permissions are necessary. Here, a top-level block is recommended for simplicity and clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
