### PR TITLE
Bump version number to 5.2.1

### DIFF
--- a/Aura-Text-setup-x64.iss
+++ b/Aura-Text-setup-x64.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Aura Text"
-#define MyAppVersion "5.1.2"
+#define MyAppVersion "5.2.1"
 #define MyAppPublisher "Rohan Kishore"
 #define MyAppURL "https://github.com/rohankishore/Aura-Text"
 #define MyAppExeName "Aura Text.exe"


### PR DESCRIPTION
This bumps version number to v5.2.1. Please do this before re-tagging the release.