### PR TITLE
Enable splash screen by default

### DIFF
--- a/LocalAppData/AuraText/data/config.json
+++ b/LocalAppData/AuraText/data/config.json
@@ -1,5 +1,5 @@
 {
-    "splash": "False",
+    "splash": "True",
     "terminal_tips": "False",
     "explorer_default_open": "False",
     "open_last_file": "False",


### PR DESCRIPTION
This just enables the splash screen in the default LocalAppData stuff supplied by the program on first launch. Please merge this; it shows users that the program is launching rather than just in a frozen or crashed state.