### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,6 +6,12 @@ permissions:
   contents: read
 
 on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -37,4 +37,4 @@ jobs:
       uses: actions/upload-artifact@v4.3.1
       with:
         name: Aura-Text
-        path: build
+        path: dist

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Build
+name: Build on Windows
 permissions:
   contents: read
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,11 +22,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt -U nuitka ordered-set zstandard
+        pip install -r requirements.txt -U
     
     - name: Build Exe
       run:
-        python -m nuitka --mingw64 --assume-yes-for-downloads --standalone --windows-console-mode=disable --jobs=8 --output-dir="build" --windows-icon-from-ico=icon.ico main.py
+        python build.py
     - name: Upload ZIP
       uses: actions/upload-artifact@v4.3.1
       with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,11 +18,11 @@ jobs:
     - name: Set up Python 3.11
       uses: actions/setup-python@v3
       with:
-        python-version: "3.11"
+        python-version: "3.13"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt -U nuitka ordered-set zstandard
+        pip install -r requirements.txt
     
     - name: Build Exe
       run:


### PR DESCRIPTION
Changes:
1. Use Python 3.13 for Windows build workflow
2. Use proper build with the build script, not some nuitka junk
3. Name it specifically
4. Make it run on main push & PR

Please merge this if it succeeds in the check, as it's very important to have proper CI if you want CI at all.