### PR TITLE
Fix respawn

### DIFF
--- a/auratext/Components/Linter.py
+++ b/auratext/Components/Linter.py
@@ -120,6 +120,7 @@ class LinterWorker(QObject):
     def _run_flake8(self) -> List[LintMessage]:
         """Run flake8 and parse output"""
         messages = []
+        return messages
         try:
             result = subprocess.run(
                 [sys.executable, '-m', 'flake8', '--format=%(row)d:%(col)d:%(code)s:%(text)s', self.temp_file],


### PR DESCRIPTION
Changes:
1. Stop the IDE from respawning itself on Windows (fix #162). This disables the linter, which never worked anyways.

Please make sure you are ok with the changes, but otherwise feel free to merge.