### PR TITLE
Fix README formatting near the start

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@
 <br>
 <hr>
 <!-- ABOUT THE PROJECT -->
-## 📖 About The Project
+<strong>📖 About The Project</strong>
 
 <img width="1920" height="1100" alt="image" src="https://github.com/user-attachments/assets/17399995-7032-4d90-957e-5cef278ceb6e" />
 <img width="1920" height="1100" alt="image" src="https://github.com/user-attachments/assets/7eb477ed-1469-4303-bce2-8124efcd8114" />

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@
 <br>
 <hr>
 <!-- ABOUT THE PROJECT -->
-<strong>📖 About The Project</strong>
+<h2>📖 About The Project</h2>
 
 <img width="1920" height="1100" alt="image" src="https://github.com/user-attachments/assets/17399995-7032-4d90-957e-5cef278ceb6e" />
 <img width="1920" height="1100" alt="image" src="https://github.com/user-attachments/assets/7eb477ed-1469-4303-bce2-8124efcd8114" />


### PR DESCRIPTION
Changes:
1. Use HTML formatting tags to make the README display the `About The Project` section header as a proper level-2 header. We use HTML tags because it's located in an HTML block in the file.

Please make sure that you are ok with the changes; otherwise, feel free to merge.