### PR TITLE
Fix fonts

### DIFF
--- a/auratext/Components/GitGraph.py
+++ b/auratext/Components/GitGraph.py
@@ -3,6 +3,8 @@ import subprocess
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QTextEdit, QRadioButton, QHBoxLayout, QGroupBox
 from PyQt6.QtGui import QFont
 
+from auratext.Misc.boilerplates import get_font_for_platform
+
 class GitGraph(QWidget):
     def __init__(self, path):
         super().__init__()
@@ -27,7 +29,7 @@ class GitGraph(QWidget):
         self.graph_display = QTextEdit()
         self.graph_display.setReadOnly(True)
         # Use a monospaced font for better graph alignment
-        font = QFont("Courier New", 10)
+        font = get_font_for_platform(size=10, plain=True)
         self.graph_display.setFont(font)
 
         self.layout.addWidget(options_group)

--- a/auratext/Components/powershell.py
+++ b/auratext/Components/powershell.py
@@ -15,6 +15,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from auratext.Misc.boilerplates import get_font_for_platform
 from auratext.Misc.import_res import notepadequalequalComponentImportPathAppend
 sys.path.append(notepadequalequalComponentImportPathAppend)
 from notepadequalequal.fileio import retrieve_file
@@ -108,7 +109,7 @@ class TerminalEmulator(QWidget):
             "Courier New",
             "Monospace",
         ]
-        font = QFont(font_families[0], 10)
+        font = get_font_for_platform(size=10, plain=True)
         font.setStyleHint(QFont.StyleHint.Monospace)
         self.terminal.setFont(font)
 

--- a/auratext/Components/statusBar.py
+++ b/auratext/Components/statusBar.py
@@ -14,6 +14,7 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QStatusBar, QWidget, QPushButton
 
 # from ..scripts.color_scheme_loader import color_schemes
+from auratext.Misc.boilerplates import get_font_for_platform
 
 if platform.system() == "Windows":
     local_app_data = os.getenv('LOCALAPPDATA')
@@ -59,7 +60,7 @@ class StatusBar(QStatusBar):
         )
 
         
-        smallFont = QFont()
+        smallFont = get_font_for_platform(size=8, plain=False)
         smallFont.setPointSize(8)
 
         # Always initialize editModeLabel first

--- a/auratext/Components/terminal.py
+++ b/auratext/Components/terminal.py
@@ -17,6 +17,7 @@ from art import text2art
 from pyjokes import pyjokes
 
 from auratext.Components.powershell import find_powershell_core as find_shellPath
+from auratext.Misc.boilerplates import get_font_for_platform
 
 now = datetime.now()
 
@@ -89,7 +90,7 @@ class AuraTextTerminalWidget(QWidget):
         self.strcmds = str(self.commands)
 
         self.script_edit = QLineEdit()
-        self.script_edit.setFont(QFont("Consolas"))
+        self.script_edit.setFont(get_font_for_platform(size=10, plain=True))
         self.setStyleSheet("QWidget {background-color: #FFFFFF;}")
         self.script_edit.setStyleSheet(
             "QLineEdit {"
@@ -115,7 +116,7 @@ class AuraTextTerminalWidget(QWidget):
         self.terminal_history_button.clicked.connect(self.terminal_history_run)
 
         self.text = QTextEdit()
-        self.text.setFont(QFont("Consolas"))
+        self.text.setFont(get_font_for_platform(size=10, plain=True))
         self.text.setReadOnly(True)
         self.text.setStyleSheet("QTextEdit {background-color: #000000;color: white; border:none;}")
 

--- a/auratext/Core/AuraText.py
+++ b/auratext/Core/AuraText.py
@@ -10,6 +10,7 @@ from . import Lexers
 from . import Modules as ModuleFile
 from .autocomplete_engine import PythonAutocompleteEngine
 
+from auratext.Misc.boilerplates import get_font_for_platform
 if TYPE_CHECKING:
     from .window import Window
 
@@ -107,7 +108,7 @@ class CodeEditor(QsciScintilla):
         lexer.setColor(QColor("#3ba800"), lexer.SingleQuotedString)
         lexer.setColor(QColor("#3ba800"), lexer.DoubleQuotedString)
         lexer.setColor(QColor("#FFFFFF"), lexer.Default)
-        lexer.setFont(QFont(window._themes["font"]))
+        lexer.setFont(get_font_for_platform())
 
         self.setTabWidth(4)
         self.setMarginLineNumbers(1, True)

--- a/auratext/Core/Lexers.py
+++ b/auratext/Core/Lexers.py
@@ -2,6 +2,7 @@
 his file includes lexer functions for all the languages supported by Aura Text. The lexer functionalities are implemented using QSciScintilla.
 """
 import re
+from auratext.Misc.boilerplates import get_font_for_platform
 
 from PyQt6.Qsci import (
     QsciLexerCPP,
@@ -48,7 +49,7 @@ class ColorCodeLexer(QsciLexerCustom):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setColor(QColor("#000000"), 0)  # Default color
-        self.setFont(QFont("Courier", 10))
+        self.setFont(get_font_for_platform(size=10, plain=True))
 
     def language(self):
         return "ColorCode"
@@ -80,7 +81,7 @@ def python(self):
     lexer.setColor(QColor("#59ff00"), lexer.TripleDoubleQuotedString)
     lexer.setColor(QColor("#3ba800"), lexer.SingleQuotedString)
     lexer.setColor(QColor("#3ba800"), lexer.DoubleQuotedString)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 class PythonLexer(QsciLexerPython):
@@ -89,7 +90,7 @@ class PythonLexer(QsciLexerPython):
         self.setDefaultColor(QColor("white"))
         self.setPaper(QColor(window._themes["editor_theme"]))
         self.setColor(QColor("#ffffff"), self.ClassName)
-        self.setFont(QFont(window._themes["font"]))
+        self.setFont(get_font_for_platform(size=10, plain=True))
 
 def csharp(self):
     lexer = QsciLexerCSharp()
@@ -98,7 +99,7 @@ def csharp(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def avs(self):
@@ -107,7 +108,7 @@ def avs(self):
     self.current_editor.setLexer(lexer)
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def asm(self):
@@ -116,7 +117,7 @@ def asm(self):
     self.current_editor.setLexer(lexer)
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def coffeescript(self):
@@ -126,7 +127,7 @@ def coffeescript(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def ma(self):
@@ -136,7 +137,7 @@ def ma(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def json(self):
@@ -145,7 +146,7 @@ def json(self):
     self.current_editor.setLexer(lexer)
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def js(self):
@@ -156,7 +157,7 @@ def js(self):
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
     lexer.setColor(QColor("#ffffff"), lexer.Default)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def fortran(self):
@@ -166,7 +167,7 @@ def fortran(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def java(self):
@@ -176,7 +177,7 @@ def java(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def bash(self):
@@ -186,7 +187,7 @@ def bash(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def yaml(self):
@@ -196,7 +197,7 @@ def yaml(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def xml(self):
@@ -204,7 +205,7 @@ def xml(self):
     lexer.setDefaultColor(QColor("#FFFFFF"))
     self.current_editor.setLexer(lexer)
     lexer.setPaper(QColor(self._themes["editor_theme"]))
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def html(self):
@@ -221,7 +222,7 @@ def html(self):
     lexer.setColor(QColor("#FFFFFF"), lexer.Entity)
     lexer.setColor(QColor("#FFFFFF"), lexer.OtherInTag)
     lexer.setColor(QColor("#569CD6"), lexer.HTMLNumber)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def cpp(self):
@@ -232,7 +233,7 @@ def cpp(self):
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
     lexer.setColor(QColor("#ffffff"), lexer.Identifier)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def srec(self):
@@ -240,7 +241,7 @@ def srec(self):
     lexer.setDefaultColor(QColor("#FFFFFF"))
     self.current_editor.setLexer(lexer)
     lexer.setPaper(QColor(self._themes["editor_theme"]))
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def ruby(self):
@@ -251,7 +252,7 @@ def ruby(self):
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
     lexer.setColor(QColor("#ffffff"), lexer.ClassName)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def perl(self):
@@ -261,7 +262,7 @@ def perl(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def css(self):
@@ -270,7 +271,7 @@ def css(self):
     self.current_editor.setLexer(lexer)
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def lua(self):
@@ -280,7 +281,7 @@ def lua(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def sql(self):
@@ -290,7 +291,7 @@ def sql(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def tex(self):
@@ -304,7 +305,7 @@ def tex(self):
     lexer.setColor(QColor("#59ff00"), lexer.Group)
     lexer.setColor(QColor("#DCDCAA"), lexer.Symbol)
     lexer.setColor(QColor("#FFFFFF"), lexer.Text)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def bat(self):
@@ -314,7 +315,7 @@ def bat(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def cmake(self):
@@ -323,7 +324,7 @@ def cmake(self):
     self.current_editor.setLexer(lexer)
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def postscript(self):
@@ -333,7 +334,7 @@ def postscript(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def markdown(self):
@@ -344,7 +345,7 @@ def markdown(self):
     lexer.setColor(QColor("#808080"), lexer.Header1)
     lexer.setColor(QColor("#FFA500"), lexer.Header2)
     lexer.setColor(QColor("#ffffff"), lexer.Header3)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def makefile(self):
@@ -353,7 +354,7 @@ def makefile(self):
     self.current_editor.setLexer(lexer)
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def pascal(self):
@@ -363,7 +364,7 @@ def pascal(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def tcl(self):
@@ -372,7 +373,7 @@ def tcl(self):
     self.current_editor.setLexer(lexer)
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def verilog(self):
@@ -382,7 +383,7 @@ def verilog(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor(self._themes["editor_theme"]), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def spice(self):
@@ -391,7 +392,7 @@ def spice(self):
     self.current_editor.setLexer(lexer)
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def vhdl(self):
@@ -401,7 +402,7 @@ def vhdl(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def octave(self):
@@ -411,7 +412,7 @@ def octave(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))
 
 
 def fortran77(self):
@@ -421,4 +422,4 @@ def fortran77(self):
     lexer.setPaper(QColor(self._themes["editor_theme"]))
     lexer.setColor(QColor("#808080"), lexer.Comment)
     lexer.setColor(QColor("#FFA500"), lexer.Keyword)
-    lexer.setFont(QFont(self._themes["font"]))
+    lexer.setFont(get_font_for_platform(size=10, plain=True))

--- a/auratext/Core/MiniMapWidget.py
+++ b/auratext/Core/MiniMapWidget.py
@@ -2,6 +2,8 @@ from PyQt6.QtWidgets import QWidget
 from PyQt6.QtGui import QPainter, QColor, QFont, QFontMetrics, QPen, QBrush
 from PyQt6.QtCore import Qt, QRect, QRectF, QTimer, QPropertyAnimation, QEasingCurve, pyqtProperty
 
+from auratext.Misc.boilerplates import get_font_for_platform
+
 class MiniMapWidget(QWidget):
     def __init__(self, editor=None, parent=None):
         super().__init__(parent)
@@ -131,7 +133,7 @@ class MiniMapWidget(QWidget):
         self.line_height = max(2, min(4, available_height / max(total_lines, 1)))
         
         # Setup minimap font - small but readable monospace
-        font = QFont("Consolas", 2)
+        font = get_font_for_platform(size=2, plain=True)
         font.setStyleHint(QFont.StyleHint.Monospace)
         font.setPixelSize(max(2, int(self.line_height * 0.9)))
         painter.setFont(font)

--- a/auratext/Core/window.py
+++ b/auratext/Core/window.py
@@ -63,6 +63,7 @@ from .AuraText import CodeEditor
 from auratext.Components.TabWidget import TabWidget
 from .plugin_interface import Plugin
 from notepadequalequal.fileio import retrieve_file
+from auratext.Misc.boilerplates import get_font_for_platform
 
 if platform.system() == "Windows":
     local_app_data = os.getenv('LOCALAPPDATA')
@@ -1136,7 +1137,7 @@ class Window(QMainWindow):
             self.dock.setWidget(self.explorer_tree_view)
             self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.dock)
 
-            self.explorer_tree_view.setFont(QFont("Consolas"))
+            self.explorer_tree_view.setFont(get_font_for_platform(plain=True))
             self.explorer_tree_view.setColumnHidden(1, True)  # File type column
             self.explorer_tree_view.setColumnHidden(2, True)  # Size column
             self.explorer_tree_view.setColumnHidden(3, True)  # Date modified column
@@ -2497,7 +2498,7 @@ class Window(QMainWindow):
     def notes(self):
         note_dock = QDockWidget("Notes", self)
         note_widget = QPlainTextEdit(note_dock)
-        note_widget.setFont(QFont(self._themes["font"]))
+        note_widget.setFont(get_font_for_platform(plain=True))
         note_dock.setWidget(note_widget)
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, note_dock)
         note_dock.show()

--- a/auratext/Misc/WelcomeScreen.py
+++ b/auratext/Misc/WelcomeScreen.py
@@ -8,10 +8,9 @@ from PyQt6.QtGui import QFont, QPixmap, QCursor
 from PyQt6.QtWidgets import (QPushButton, QWidget, QVBoxLayout, QLabel, 
                              QHBoxLayout, QScrollArea, QFrame)
 
-
+from auratext.Misc.boilerplates import get_font_for_platform
 if TYPE_CHECKING:
     from auratext.Core.window import Window
-
 
 class ActionButton(QPushButton):
     """VS Code-style action button"""
@@ -172,11 +171,11 @@ class WelcomeWidget(QWidget):
         
         # Title Section
         title_label = QLabel("Aura Text")
-        title_label.setFont(QFont("Segoe UI", 48, QFont.Weight.Light))
+        title_label.setFont(get_font_for_platform(size=48, plain=False))
         title_label.setStyleSheet("color: #cccccc;")
         
         subtitle_label = QLabel("Like any text editor. Unlike any text editor")
-        subtitle_label.setFont(QFont("Segoe UI", 16))
+        subtitle_label.setFont(get_font_for_platform(size=16, plain=False))
         subtitle_label.setStyleSheet("color: #888888; margin-bottom: 20px;")
         
         main_layout.addWidget(title_label)
@@ -191,7 +190,7 @@ class WelcomeWidget(QWidget):
         start_column.setSpacing(15)
         
         start_header = QLabel("Start")
-        start_header.setFont(QFont("Segoe UI", 14, QFont.Weight.Bold))
+        start_header.setFont(get_font_for_platform(size=14, plain=False))
         start_header.setStyleSheet("color: #cccccc; margin-bottom: 5px;")
         start_column.addWidget(start_header)
         
@@ -232,7 +231,7 @@ class WelcomeWidget(QWidget):
         walkthrough_column.setSpacing(15)
         
         walkthrough_header = QLabel("Walkthroughs")
-        walkthrough_header.setFont(QFont("Segoe UI", 14, QFont.Weight.Bold))
+        walkthrough_header.setFont(get_font_for_platform(size=14, plain=False))
         walkthrough_header.setStyleSheet("color: #cccccc; margin-bottom: 5px;")
         walkthrough_column.addWidget(walkthrough_header)
         
@@ -288,7 +287,7 @@ class WelcomeWidget(QWidget):
         
         # Recent Projects Section
         recent_header = QLabel("Recent")
-        recent_header.setFont(QFont("Segoe UI", 14, QFont.Weight.Bold))
+        recent_header.setFont(get_font_for_platform(size=14, plain=False))
         recent_header.setStyleSheet("color: #cccccc; margin-top: 10px; margin-bottom: 5px;")
         main_layout.addWidget(recent_header)
         

--- a/auratext/Misc/boilerplates.py
+++ b/auratext/Misc/boilerplates.py
@@ -18,6 +18,7 @@ from PyQt6.QtWidgets import (
     QListWidget,
     QLabel,
     QDialog)
+from PyQt6.QtGui import QFont
 
 from auratext.Misc.import_res import notepadequalequalComponentImportPathAppend
 sys.path.append(notepadequalequalComponentImportPathAppend)
@@ -83,3 +84,19 @@ class BoilerPlate(QDialog):
             self.current_editor.append(file_contents)
         except Exception as e:
             print(f"Error reading file: {e}")
+
+def get_font_for_platform(size=12, plain=True):
+    system_name = platform.system()
+    if system_name == "Windows":
+        if plain == True:
+            return QFont("Consolas", size)
+        else:
+            return QFont("Arial", size)
+    elif system_name == "Darwin":
+        if plain:
+            return QFont("Menlo", size)
+        else:
+            return QFont("Helvetica", size)
+    else:
+        print("WARNING: No non-plain font is available on your platform.")
+        return QFont("DejaVu Sans Mono", size)


### PR DESCRIPTION
Changes:
1. Add the `get_font_for_platform` function that allows the program to default to a working font, given platform, rather than the program defaulting to one that may only exist on a platform or not at all
2. Fix all the broken fonts, reducing launch time of Qt defaulting fonts by at least 50-100 ms

Please make sure you are ok with the changes; otherwise, feel free to merge.