### PR TITLE
Fix linux non-monospace fonts by defaulting to noto sans

### DIFF
--- a/auratext/Misc/boilerplates.py
+++ b/auratext/Misc/boilerplates.py
@@ -98,5 +98,7 @@ def get_font_for_platform(size=12, plain=True):
         else:
             return QFont("Helvetica", size)
     else:
-        print("WARNING: No non-plain font is available on your platform.")
-        return QFont("DejaVu Sans Mono", size)
+        if plain:
+            return QFont("DejaVu Sans Mono", size)
+        else:
+            return QFont("Noto Sans", size)


### PR DESCRIPTION
This PR fixes Linux installs not defaulting to a working non-monospace font. It defaults to Noto Sans, which is defaulted to by GTK & Tkinter as a system font, and so is certainly present if PyQt is running in that environment. Please merge this as it fixes a UI/UX issue and does not affect the program in any major way at all.