### PR TITLE
Add GNU nano & macOS annoyances to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,13 @@ __marimo__/
 # Inno Setup build artifacts
 Output/
 auratext/elements.db
+
+# GNU nano annoyances
+*.swp
+*.save
+
+
+# macOS annoyances
+.DS_Store
+._*
+*DS_Store


### PR DESCRIPTION
This PR adds temporary files that my favorite editor, `nano`, generates during runtime & macOS metadata files to the gitignore. Please merge it as we should avoid committing junk as much as possible.