### PR TITLE
Fix macOS compatibility label in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ With Aura Text, users can access a versatile and powerful editing environment. W
 Let's set up Aura Text on your PC!
 
 ### Prerequisites
-- Windows 10 x64 or later, a Linux distro running kernel 6.x or later, or macOS High Sierra or later 
+- Windows 10 x64 or later, a Linux distro running kernel 6.x or later, or macOS Ventura or later 
 - Python 3.9 or later
 - Python installation is bootstrapped with pip
 - (Recommended) A fresh venv created with `python -m venv venv` and activated with `venv\Scripts\activate`


### PR DESCRIPTION
PyQt6 only works on macOS Ventura, so the program would only be able to run on macOS Ventura or later.