### PR TITLE
Remove rogue qdrag object

### DIFF
--- a/auratext/Core/TabWidget.py
+++ b/auratext/Core/TabWidget.py
@@ -1,5 +1,5 @@
 from PyQt6.QtCore import QMimeData, QPoint, Qt
-from PyQt6.QtGui import QCursor, QDrag, QPixmap, QRegion, QAction
+from PyQt6.QtGui import QPixmap, QRegion, QAction
 from PyQt6.QtWidgets import QTabWidget, QMenu
 
 
@@ -44,11 +44,15 @@ class TabWidget(QTabWidget):
 
         pixmap = QPixmap(tabRect.size())
         tabBar.render(pixmap, QPoint(), QRegion(tabRect))
-        mimeData = QMimeData()
-        
-        drag = QDrag(self)
-        drag.setMimeData(mimeData)
-        drag.exec()
+        mimeData = QMimeData()
+
+        
+
+        # drag = QDrag(self)
+
+        # drag.setMimeData(mimeData)
+
+        # drag.exec()
 
     def contextMenuEvent(self, event):
         menu = QMenu(self)


### PR DESCRIPTION
This PR removes this useless annoying QDrag object that follows the cursor and slows the IDE to a crawl when the mouse moves.