### PR TITLE
Prefer appdata next to script but also accept next to interpreter

### DIFF
--- a/Aura-Text-setup-x64.iss
+++ b/Aura-Text-setup-x64.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Aura Text"
-#define MyAppVersion "5.4.2"
+#define MyAppVersion "5.5.0"
 #define MyAppPublisher "Rohan Kishore"
 #define MyAppURL "https://github.com/rohankishore/Aura-Text"
 #define MyAppExeName "Aura Text.exe"

--- a/auratext/Components/About.py
+++ b/auratext/Components/About.py
@@ -36,7 +36,7 @@ class AboutAppDialog(QDialog):
         # App description
         description = QLabel("Aura Text is a versatile and powerful text editor powered by QScintilla that provides all the necessary tools for developers. It is build using PyQt6 and Python."
                              "\n" + "\n" 
-                             "Version: v5.4.2" + "\n" + "\n" + "\n" + "Made with ❣️ by Rohan Kishore")
+                             "Version: v5.5.0" + "\n" + "\n" + "\n" + "Made with ❣️ by Rohan Kishore")
         description.setWordWrap(True)
         description.setAlignment(Qt.AlignmentFlag.AlignCenter)
 

--- a/main.py
+++ b/main.py
@@ -38,6 +38,8 @@ It will then load the config and theme files to apply the user's settings and th
 local_app_data, script_dir = get_appdata_dirs()
 
 template_app_data = os.path.join(os.path.dirname(os.path.abspath(__file__)), "LocalAppData", "AuraText")
+if not os.path.exists(template_app_data):
+    template_app_data = os.path.join(os.path.dirname(sys.executable), "LocalAppData", "AuraText")
 if not os.path.exists(local_app_data):
     print("Setting up appdata...")
     shutil.copytree(template_app_data, local_app_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aura-text"
-version = "5.4.2"
+version = "5.5.0"
 description = "Aura Text is a versatile and powerful text editor powered by QScintilla that provides all the necessary tools for developers. It is build using PyQt6 and Python."
 authors = ["Rohan Kishore (@rohankishore on GitHub)"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
This fixes bundled apps crashing. The problem we have here is that the appdata next to executable is not being accepted. Therefore we allow the appdata to either be next to the script (preferred) or next to the interpreter