### PR TITLE
Some misc updates after the version control settings update

### DIFF
--- a/auratext/Components/GitCommit.py
+++ b/auratext/Components/GitCommit.py
@@ -44,7 +44,7 @@ class commitSettingsDialog(QDialog):
             }}
         """)
 
-        self.setWindowTitle("Commit Settings")
+        self.setWindowTitle("Version Control Settings")
         self.setMinimumHeight(150)
         self.setMinimumWidth(300)
 

--- a/auratext/Components/GitGraph.py
+++ b/auratext/Components/GitGraph.py
@@ -1,7 +1,8 @@
 
 import subprocess
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QTextEdit, QRadioButton, QHBoxLayout, QGroupBox
+from PyQt6.QtWidgets import QMessageBox, QWidget, QVBoxLayout, QTextEdit, QRadioButton, QHBoxLayout, QGroupBox
 from PyQt6.QtGui import QFont
+from PyQt6.QtCore import QTimer
 
 from auratext.Misc.boilerplates import get_font_for_platform
 
@@ -69,6 +70,7 @@ class GitGraph(QWidget):
                 self.graph_display.setText(process.stdout)
             else:
                 self.graph_display.setText(f"Error fetching Git log:\n{process.stderr}")
+                QTimer.singleShot(0, lambda: QMessageBox.warning(self, "Git Error", f"Error fetching Git log:\n{process.stderr}"))
 
         except FileNotFoundError:
             self.graph_display.setText("Either Git is not installed or you have not opened a Git repository. Please ensure Git is installed and you have a Git repository opened.")

--- a/auratext/Core/MenuConfig.py
+++ b/auratext/Core/MenuConfig.py
@@ -4,6 +4,7 @@ import os
 import sys
 import platform
 
+from PyQt6.QtCore import QTimer
 from PyQt6.QtWidgets import QMenu
 from PyQt6.QtGui import QAction, QIcon
 
@@ -567,17 +568,15 @@ QMenu::item::selected {{
                             if section in sections:
                                 plugin.add_menu_items(sections[section])
                 except Exception as e:
-
-                    QMessageBox.critical(
-
-                        self,
-
-                        "Plugin Load Error",
-
-                        f"Error loading plugin '{plugin_module_name}':\n{e}"
-
-                    )
-
+                    error = str(e)
+                    def pluginLoadError(selfObject, plugin_module_name, e):
+                        QMessageBox.warning(
+                            selfObject,
+                            "Non-Critical Plugin Load Error",
+                            f"Error loading plugin '{plugin_module_name}':\n{e}"
+                        )
+                        print(f"Error loading plugin '{plugin_module_name}': {e}")
+                    QTimer.singleShot(0, lambda: pluginLoadError(self, plugin_module_name, error))
 
     for section, submenu in sections.items():
         menubar.addMenu(submenu)

--- a/auratext/Core/Modules.py
+++ b/auratext/Core/Modules.py
@@ -297,6 +297,7 @@ def pastebin(self):
         text_pb = self.current_editor.text()
     except AttributeError:
         QMessageBox.warning(self, "No Editor Open", "The current widget is not an editor.")
+        return
     if text_pb != "":
         data = {"api_dev_key": api_key_pastebin, "api_option": "paste", "api_paste_code": text_pb}
         response = (requests.post("https://pastebin.com/api/api_post.php", data=data)).text

--- a/auratext/Core/ThemeDownload.py
+++ b/auratext/Core/ThemeDownload.py
@@ -62,6 +62,7 @@ class ThemeDownloader(QWidget):
 
     username = "rohankishore"
     repo = "AuraText-Themes"
+    branch = "main"
 
     def get_theme_list(self):
         api_url = f"https://api.github.com/repos/{self.username}/{self.repo}/contents/Themes"
@@ -81,7 +82,7 @@ class ThemeDownloader(QWidget):
 
     def download_theme(self, file_name):
         selected_file = file_name + ".json"
-        download_url = f"https://raw.githubusercontent.com/{self.username}/{self.repo}/main/Themes/{selected_file}"
+        download_url = f"https://raw.githubusercontent.com/{self.username}/{self.repo}/{self.branch}/Themes/{selected_file}"
         response = requests.get(download_url)
 
         if response.status_code == 200:

--- a/auratext/Core/window.py
+++ b/auratext/Core/window.py
@@ -47,7 +47,7 @@ from . import PluginDownload
 from . import ThemeDownload
 from . import config_page
 from .CommandPalette import CommandPalette
-from ..Components import powershell, terminal, statusBar, ProjectManager, About, ToDo, GitGraph, GitRebase, Performance, RegexPlayground
+from ..Components import powershell, terminal, statusBar, ProjectManager, About, ToDo, GitCommit, GitGraph, GitRebase, Performance, RegexPlayground
 from ..Components.CommandPalette import CommandPalette
 from ..Components.NewProjectDialog import NewProjectDialog
 from ..Components.Linter import CodeLinter


### PR DESCRIPTION
This PR mostly fixes a few things with the version control, but also fixes a few other bugs:
1. Version Control Settings is what it should be called, not a generic dialog
2. Plugin errors are not critical and should not block program from loading
3. Also show a dialog box when GitGraph fails
4. Import GitCommit where it's missing